### PR TITLE
Update CaseQuestionRepo.cs

### DIFF
--- a/ExcelDynamicCase/Domain/CaseQuestions/CaseQuestionRepo.cs
+++ b/ExcelDynamicCase/Domain/CaseQuestions/CaseQuestionRepo.cs
@@ -2341,7 +2341,7 @@ namespace ExcelDynamicCase.Domain.CaseQuestions
                             }
                         }
                     },
-                    Answer = "103",
+                    Answer = "93",
                     ExampleAnswer = 70d,
                     Minutes = 10f,
                 }


### PR DESCRIPTION
I kept getting LaytonButtonToButton wrong - when I cheated and looked it up, I spotted a typo in R5 C4:

Your version:
{"3E","4S","2W","2W","2S",},
{"3E","3E","3S","2W","2S",},
{"1E","1S","Star","3W","2W",},
{"2N","1W","3N","1N","2W",},
{"4E","1W","1E",**"1E"**,"4N",}

Layton version:
{"3E","4S","2W","2W","2S",},
{"3E","3E","3S","2W","2S",},
{"1E","1S","Star","3W","2W",},
{"2N","1W","3N","1N","2W",},
{"4E","1W","1E",**"1N"**,"4N",}